### PR TITLE
Configure Rspec i18n locales and squash ENV layers in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM ruby:2.6.0
 LABEL maintainer="hola@decidim.org"
 
-ENV USER_ID 1000
-ENV GROUP_ID 2000
-ENV RAILS_ENV production
-ENV LANG=C.UTF-8
-ENV BUNDLE_JOBS=20
-ENV BUNDLE_RETRY=5
-ENV APP_HOME /usr/src/app/
-ENV PATH=${APP_HOME}/bin:${PATH}
-ENV SECRET_KEY_BASE dummy_key_base
+ENV USER_ID=1000 \
+    GROUP_ID=2000 \
+    RAILS_ENV=production \
+    LANG=C.UTF-8 \
+    BUNDLE_JOBS=20 \
+    BUNDLE_RETRY=5 \
+    APP_HOME=/usr/src/app/ \
+    PATH=${APP_HOME}/bin:${PATH} \
+    SECRET_KEY_BASE=dummy_key_base
 
 RUN apt-get update -qq \
     && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,3 +5,13 @@ require "decidim/dev"
 Decidim::Dev.dummy_app_path = File.expand_path(Rails.root.to_s)
 
 require "decidim/dev/test/base_spec_helper"
+
+RSpec.configure do |config|
+  config.before(:each) do
+    I18n.available_locales = %i(en ca es)
+    I18n.default_locale = :en
+    I18n.locale = :en
+    Decidim.available_locales = %i(en ca es)
+    Decidim.default_locale = :en
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,11 +7,11 @@ Decidim::Dev.dummy_app_path = File.expand_path(Rails.root.to_s)
 require "decidim/dev/test/base_spec_helper"
 
 RSpec.configure do |config|
-  config.before(:each) do
-    I18n.available_locales = %i(en ca es)
+  config.before do
+    I18n.available_locales = [:en, :ca, :es]
     I18n.default_locale = :en
     I18n.locale = :en
-    Decidim.available_locales = %i(en ca es)
+    Decidim.available_locales = [:en, :ca, :es]
     Decidim.default_locale = :en
   end
 end


### PR DESCRIPTION
### What ? Why? 

Configure Rspec i18n locales for always testing apps using English language by default.
Squash ENV variables in Dockerfile into a unique `ENV` layer.

### Tasks
- [x] Squash ENV layers in `Dockerfile`
- [x] Configure English locale by default in Rspec configuration